### PR TITLE
Remove tags prefix

### DIFF
--- a/src/providers.tf
+++ b/src/providers.tf
@@ -14,6 +14,6 @@ provider "aws" {
 }
 
 module "iam_roles" {
-  source  = "github.com/cloudposse-terraform-components/aws-account-map//src/modules/iam-roles?ref=tags/v1.535.3"
+  source  = "github.com/cloudposse-terraform-components/aws-account-map//src/modules/iam-roles?ref=v1.535.3"
   context = module.this.context
 }


### PR DESCRIPTION
## what
* The change updates the `source` URL for modules to remove the `tags/` prefix in the version reference.

## why
* Terraform handles incorrectly git paths which have slashes in ref parameter

## references
* https://github.com/hashicorp/go-getter/issues/469
* https://github.com/cloudposse-terraform-components/aws-datadog-credentials/pull/33
* https://github.com/cloudposse/test-harness/pull/56

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version reference format for a module dependency to improve consistency. No changes to functionality or configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->