### PR TITLE
feat: expose manage_alerts to control jsonData.manageAlerts

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -1,5 +1,16 @@
 locals {
   enabled = module.this.enabled
+
+  json_data = merge(
+    {
+      sigV4Auth          = true
+      httpMethod         = "POST"
+      sigV4AuthType      = "ec2_iam_role"
+      sigV4AssumeRoleArn = module.prometheus.outputs.access_role_arn
+      sigV4Region        = module.prometheus.outputs.workspace_region
+    },
+    var.manage_alerts != null ? { manageAlerts = var.manage_alerts } : {},
+  )
 }
 
 resource "grafana_data_source" "managed_prometheus" {
@@ -10,11 +21,5 @@ resource "grafana_data_source" "managed_prometheus" {
   uid  = module.prometheus.outputs.id
   url  = module.prometheus.outputs.workspace_endpoint
 
-  json_data_encoded = jsonencode({
-    sigV4Auth          = true
-    httpMethod         = "POST"
-    sigV4AuthType      = "ec2_iam_role"
-    sigV4AssumeRoleArn = module.prometheus.outputs.access_role_arn
-    sigV4Region        = module.prometheus.outputs.workspace_region
-  })
+  json_data_encoded = jsonencode(local.json_data)
 }

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -26,3 +26,21 @@ variable "prometheus_tenant_name" {
   description = "The tenant where the Amazon Managed Prometheus component is deployed"
   default     = ""
 }
+
+variable "manage_alerts" {
+  type        = bool
+  description = <<-EOT
+    Sets the `manageAlerts` field in the datasource's `jsonData`. Controls
+    whether Grafana's Alerting UI tries to enumerate and manage alert rules
+    stored on the datasource's own ruler API. AMP does not currently expose
+    a Grafana-compatible ruler endpoint, so leaving this enabled (Grafana's
+    default) causes the UI to surface "Failed to load the data source
+    configuration / Unable to fetch alert rules" continuously after the
+    workspace migrates to Grafana unified alerting. Setting this to false
+    suppresses that lookup. Has no effect on Grafana unified-alerting rules
+    that query AMP for data, on dashboards, or on AMP ingestion. Default is
+    null (no `manageAlerts` key emitted; relies on Grafana's server-side
+    default of true) to preserve existing behaviour for callers.
+  EOT
+  default     = null
+}


### PR DESCRIPTION
## what

Adds an optional `manage_alerts` (bool) variable that, when set, plumbs `manageAlerts` into the datasource's `jsonData`. Default `null` preserves existing behaviour (no `manageAlerts` key is emitted, Grafana falls back to its server-side default of `true`).

## why

`manageAlerts` controls whether Grafana's Alerting UI calls each datasource's ruler API (`/api/v1/rules`) to enumerate and manage alert rules stored on the datasource side (the disjoint world to Grafana-stored unified-alerting rules).

Amazon Managed Prometheus does not currently expose a Grafana-compatible ruler endpoint. After a workspace migrates to Grafana unified alerting (`unifiedAlerting.enabled = true` in the workspace `configuration` JSON — merged via [cloudposse/terraform-aws-managed-grafana#12](https://github.com/cloudposse/terraform-aws-managed-grafana/pull/12)), the Alerting UI surfaces a continuous error per AMP datasource:

> Failed to load the data source configuration for `vbpt-data-usw2-prod-prometheus`: Unable to fetch alert rules. Is the `vbpt-data-usw2-prod-prometheus` data source properly configured?

Setting `manage_alerts = false` skips the lookup. The change has **no effect** on:

- Grafana unified-alerting rules that *query* AMP for data (those use the query API, not the ruler)
- Dashboards
- AMP ingestion or remote_write paths
- Self-hosted Loki / Prometheus datasources, which expose working rulers and want `manageAlerts = true`

It only disables a UI feature for managing AMP-side rules — which AMP doesn't host anyway.

## example usage

```hcl
module "grafana_amp_datasource" {
  source = "cloudposse-terraform-components/aws-managed-grafana-data-source-managed-prometheus/aws"

  manage_alerts = false   # AMP has no ruler; suppress the UI lookup error

  # ... other args ...
}
```

## references

- [Grafana docs: Configure data sources / manage alerts](https://grafana.com/docs/grafana/latest/datasources/prometheus/configure/)
- [AMG: Alerts in Grafana version 10](https://docs.aws.amazon.com/grafana/latest/userguide/v10-alerts.html)
- Sister PR enabling unified alerting on the workspace: [cloudposse/terraform-aws-managed-grafana#12](https://github.com/cloudposse/terraform-aws-managed-grafana/pull/12)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable option to control whether Grafana's alerting interface manages alert rules through the datasource. The setting defaults to the previous behavior, maintaining backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->